### PR TITLE
Feature: inline library and drills overlays on top of the board

### DIFF
--- a/pages/drills.html
+++ b/pages/drills.html
@@ -217,6 +217,7 @@ bootstrapPreferenceAttributes();
 
 <script type="module">
 import { createPreferenceController, normalizeLang } from '../src/shared/page-prefs.js';
+import { applyPlayFromCatalog, bindOverlayBackLink, getBoardApp, isOverlayMode } from '../src/features/drills/index.js';
 
 const RECENTS_KEY = 'playRecentsV1';
 const themeButtons = {
@@ -289,6 +290,9 @@ const I18N = {
 let drills = [];
 let plays = [];
 let activeVideoId = '';
+
+const overlayMode = isOverlayMode(window);
+const boardApp = getBoardApp(window);
 
 function t(key, vars = {}){
   const dict = I18N[normalizeLang(uiLang)] || I18N.zh;
@@ -435,11 +439,11 @@ function playVideo(id, title){
   document.getElementById('player').hidden = false;
 }
 
-function applyPlay(playId){
-  if (!playId) return;
-  markRecent(playId);
-  try { localStorage.setItem('applyPlayId', playId); } catch(_) {}
-  location.href = '../index.html?apply=' + encodeURIComponent(playId);
+async function applyPlay(playId){
+  const pid = String(playId || '').trim();
+  if (!pid) return;
+  markRecent(pid);
+  await applyPlayFromCatalog(pid, { boardApp, fallbackHref: '../index.html?apply=' });
 }
 
 const preferenceController = createPreferenceController({
@@ -460,6 +464,16 @@ document.getElementById('player-open').onclick = () => {
   if (!activeVideoId) return;
   window.open(`https://www.youtube.com/watch?v=${activeVideoId}`, '_blank');
 };
+if (overlayMode) {
+  bindOverlayBackLink(document, () => {
+    try { boardApp?.closeOverlay?.(); } catch (_) {}
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      try { boardApp?.closeOverlay?.(); } catch (_) {}
+    }
+  });
+}
 
 document.getElementById('list').addEventListener('click', (e) => {
   const playBtn = e.target.closest('.js-play');

--- a/pages/library.html
+++ b/pages/library.html
@@ -258,6 +258,7 @@ bootstrapPreferenceAttributes();
 
 <script type="module">
 import { createPreferenceController, normalizeLang } from '../src/shared/page-prefs.js';
+import { applyPlayFromCatalog, bindOverlayBackLink, getBoardApp, isOverlayMode } from '../src/features/library/index.js';
 
 const FAVORITES_KEY = 'playFavoritesV1';
 const RECENTS_KEY = 'playRecentsV1';
@@ -354,6 +355,9 @@ const I18N = {
 
 let plays = [];
 let previewPlayId = '';
+
+const overlayMode = isOverlayMode(window);
+const boardApp = getBoardApp(window);
 let presetGetter = null;
 let triedImportPreset = false;
 
@@ -711,10 +715,11 @@ async function preview(id){
   document.getElementById('preview-modal').hidden = false;
 }
 
-function applyPlay(id){
-  markRecent(id);
-  try { localStorage.setItem('applyPlayId', id); } catch(_) {}
-  location.href = '../index.html?apply=' + encodeURIComponent(id);
+async function applyPlay(id){
+  const pid = String(id || '').trim();
+  if (!pid) return;
+  markRecent(pid);
+  await applyPlayFromCatalog(pid, { boardApp, fallbackHref: '../index.html?apply=' });
 }
 
 const preferenceController = createPreferenceController({
@@ -758,6 +763,16 @@ document.getElementById('pv-apply').onclick = () => {
   if (!previewPlayId) return;
   applyPlay(previewPlayId);
 };
+if (overlayMode) {
+  bindOverlayBackLink(document, () => {
+    try { boardApp?.closeOverlay?.(); } catch (_) {}
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      try { boardApp?.closeOverlay?.(); } catch (_) {}
+    }
+  });
+}
 window.addEventListener('storage', (e) => {
   preferenceController.handleStorageEvent(e);
   if (e.key === FAVORITES_KEY || e.key === RECENTS_KEY){

--- a/src/app/register-catalog.js
+++ b/src/app/register-catalog.js
@@ -1,1 +1,64 @@
-export function registerCatalog() {}
+const CATALOG_LINKS = [
+  { id: 'link-library', overlay: 'library', href: 'pages/library.html?overlay=1' },
+  { id: 'immersive-link-library', overlay: 'library', href: 'pages/library.html?overlay=1' },
+  { id: 'link-drills', overlay: 'drills', href: 'pages/drills.html?overlay=1' },
+  { id: 'immersive-link-drills', overlay: 'drills', href: 'pages/drills.html?overlay=1' }
+];
+
+function isPlainActivationEvent(e) {
+  return !!e && !e.defaultPrevented && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey;
+}
+
+function createOverlayFrame(doc, url, title) {
+  const frame = doc.createElement('iframe');
+  frame.src = url;
+  frame.title = title;
+  frame.setAttribute('allow', 'autoplay; encrypted-media; picture-in-picture');
+  frame.referrerPolicy = 'strict-origin-when-cross-origin';
+  frame.style.cssText = [
+    'width:100%',
+    'height:100%',
+    'border:0',
+    'display:block',
+    'background:#fff'
+  ].join(';');
+  return frame;
+}
+
+export function registerCatalog(app) {
+  const doc = app.document || document;
+  const overlayRoot = app.refs.overlayRoot || null;
+
+  function openCatalogOverlay(kind, href, title) {
+    if (!overlayRoot || !app.openOverlay) {
+      location.href = href;
+      return false;
+    }
+    const frame = createOverlayFrame(doc, href, title);
+    app.openOverlay(kind, frame);
+    return true;
+  }
+
+  app.openLibraryOverlay = function openLibraryOverlay() {
+    return openCatalogOverlay('library', 'pages/library.html?overlay=1', 'Play Library');
+  };
+
+  app.openDrillsOverlay = function openDrillsOverlay() {
+    return openCatalogOverlay('drills', 'pages/drills.html?overlay=1', 'Drill Library');
+  };
+
+  CATALOG_LINKS.forEach(({ id, overlay, href }) => {
+    const el = doc.getElementById(id);
+    if (!el) return;
+    const title = overlay === 'library' ? 'Play Library' : 'Drill Library';
+    el.addEventListener('click', (e) => {
+      if (!isPlainActivationEvent(e)) return;
+      e.preventDefault();
+      if (overlay === 'library') {
+        openCatalogOverlay('library', href, title);
+      } else {
+        openCatalogOverlay('drills', href, title);
+      }
+    });
+  });
+}

--- a/src/features/drills/index.js
+++ b/src/features/drills/index.js
@@ -1,0 +1,40 @@
+export function isOverlayMode(win = window) {
+  try {
+    return new URLSearchParams(win.location.search).get('overlay') === '1' || win.parent !== win;
+  } catch (_) {
+    return false;
+  }
+}
+
+export function getBoardApp(win = window) {
+  try {
+    return win.parent !== win ? win.parent.__aiHoopsBoardApp || null : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+export function bindOverlayBackLink(doc = document, onClose = () => {}) {
+  const backLink = doc.getElementById('back-link');
+  if (!backLink) return () => {};
+  const handler = (e) => {
+    e.preventDefault();
+    onClose();
+  };
+  backLink.addEventListener('click', handler);
+  return () => backLink.removeEventListener('click', handler);
+}
+
+export async function applyPlayFromCatalog(
+  playId,
+  { boardApp = getBoardApp(), fallbackHref = '../index.html?apply=' } = {}
+) {
+  const pid = String(playId || '').trim();
+  if (!pid) return false;
+  if (boardApp && typeof boardApp.applyPlayById === 'function') {
+    await boardApp.applyPlayById(pid, { sourceKey: 'source_link' });
+    return true;
+  }
+  location.href = fallbackHref + encodeURIComponent(pid);
+  return true;
+}

--- a/src/features/library/index.js
+++ b/src/features/library/index.js
@@ -1,0 +1,40 @@
+export function isOverlayMode(win = window) {
+  try {
+    return new URLSearchParams(win.location.search).get('overlay') === '1' || win.parent !== win;
+  } catch (_) {
+    return false;
+  }
+}
+
+export function getBoardApp(win = window) {
+  try {
+    return win.parent !== win ? win.parent.__aiHoopsBoardApp || null : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+export function bindOverlayBackLink(doc = document, onClose = () => {}) {
+  const backLink = doc.getElementById('back-link');
+  if (!backLink) return () => {};
+  const handler = (e) => {
+    e.preventDefault();
+    onClose();
+  };
+  backLink.addEventListener('click', handler);
+  return () => backLink.removeEventListener('click', handler);
+}
+
+export async function applyPlayFromCatalog(
+  playId,
+  { boardApp = getBoardApp(), fallbackHref = '../index.html?apply=' } = {}
+) {
+  const pid = String(playId || '').trim();
+  if (!pid) return false;
+  if (boardApp && typeof boardApp.applyPlayById === 'function') {
+    await boardApp.applyPlayById(pid, { sourceKey: 'source_link' });
+    return true;
+  }
+  location.href = fallbackHref + encodeURIComponent(pid);
+  return true;
+}

--- a/src/ui/overlay-shell.js
+++ b/src/ui/overlay-shell.js
@@ -3,22 +3,38 @@ export function attachOverlayShell(app) {
   if (!root) {
     root = document.createElement('div');
     root.id = 'overlay-root';
-    root.hidden = true;
     document.body.appendChild(root);
     app.refs.overlayRoot = root;
   }
 
+  root.hidden = true;
+  root.setAttribute('aria-hidden', 'true');
+  root.style.position = 'fixed';
+  root.style.inset = '0';
+  root.style.zIndex = '2400';
+  root.style.display = 'block';
+  root.style.pointerEvents = 'auto';
+
   app.openOverlay = function openOverlay(name, content = null) {
     root.dataset.overlay = String(name || '');
     root.hidden = false;
+    root.setAttribute('aria-hidden', 'false');
     if (content instanceof Node) {
       root.replaceChildren(content);
+    } else if (typeof content === 'string') {
+      root.innerHTML = content;
     }
+    return root;
   };
 
   app.closeOverlay = function closeOverlay() {
     root.hidden = true;
+    root.setAttribute('aria-hidden', 'true');
     root.replaceChildren();
     delete root.dataset.overlay;
+  };
+
+  app.getOverlayRoot = function getOverlayRoot() {
+    return root;
   };
 }


### PR DESCRIPTION
Closes #6
Part of #3

## Summary
- open Library and Drills inside an in-board overlay instead of leaving the board
- add shared overlay-aware helpers so embedded pages can call the parent board API directly
- remove the old `localStorage` redirect dependency for overlay apply flow while keeping standalone pages working

## Notes
- this PR is stacked on top of #10
- standalone `pages/library.html` and `pages/drills.html` remain available as fallback routes

## Smoke Test
- agent lane verified `git diff --check`
- agent lane verified module imports for overlay feature files

## Preview
- preview deploy pending Vercel project linking in the quality/deploy lane