### PR TITLE
Feature: selection editing and full-scene undo/redo

### DIFF
--- a/src/app/register-core.js
+++ b/src/app/register-core.js
@@ -58,11 +58,15 @@ export function registerCore(app) {
   if (app.refs.$('undo')) app.refs.$('undo').onclick = () => app.undo();
   if (app.refs.$('redo')) app.refs.$('redo').onclick = () => app.redo();
   if (app.refs.$('clear')) app.refs.$('clear').onclick = () => {
+    app.cancelCurrentInteraction();
     app.pushUndo();
     app.state.shapes = [];
+    if (app.clearSelection) app.clearSelection({ redraw: false });
     app.draw();
   };
   if (app.refs.$('toggle-court')) app.refs.$('toggle-court').onclick = () => {
+    app.cancelCurrentInteraction();
+    app.pushUndo();
     app.state.court = app.state.court === 'half' ? 'full' : 'half';
     app.updateCanvasAspect();
     app.resizeForDPI();
@@ -74,7 +78,11 @@ export function registerCore(app) {
     app.draw();
     app.toast(app.t('toast_view_reset'));
   };
-  if (app.refs.offenseSelect) app.refs.offenseSelect.onchange = (e) => app.setBallHandlerById((e.target && e.target.value) || '1');
+  if (app.refs.offenseSelect) app.refs.offenseSelect.onchange = (e) => {
+    const next = (e.target && e.target.value) || '1';
+    if (String(next) !== String(app.currentBallHandlerId())) app.pushUndo();
+    app.setBallHandlerById(next);
+  };
   if (app.refs.quickPlaySelect) {
     app.refs.quickPlaySelect.onchange = async (e) => {
       const id = (e.target && e.target.value) || '';
@@ -84,7 +92,11 @@ export function registerCore(app) {
     };
   }
   if (app.refs.randomPlayBtn) app.refs.randomPlayBtn.onclick = () => app.applyRandomPlay();
-  if (app.refs.toggleDefenseBtn) app.refs.toggleDefenseBtn.onclick = () => app.setDefendersRemoved(!app.areDefendersRemoved());
+  if (app.refs.toggleDefenseBtn) app.refs.toggleDefenseBtn.onclick = () => {
+    app.cancelCurrentInteraction();
+    app.pushUndo();
+    app.setDefendersRemoved(!app.areDefendersRemoved());
+  };
   if (app.refs.$('export')) {
     app.refs.$('export').onclick = async () => {
       const opts = await app.promptExportOptions();
@@ -94,9 +106,14 @@ export function registerCore(app) {
   }
   if (app.refs.$('erase')) {
     app.refs.$('erase').onclick = () => {
+      if (app.getSelection && app.getSelection()) {
+        if (app.deleteSelectedObject && app.deleteSelectedObject()) return;
+        return;
+      }
       if (!app.state.shapes.length) return;
       app.pushUndo();
       app.state.shapes.pop();
+      if (app.clearSelection) app.clearSelection({ redraw: false });
       app.draw();
       app.toast(app.t('toast_erased_last'));
     };
@@ -117,6 +134,7 @@ export function registerCore(app) {
       }
       try {
         const data = JSON.parse(raw);
+        app.cancelCurrentInteraction();
         app.pushUndo();
         app.restoreScene(data);
         app.toast(app.t('toast_loaded'));

--- a/src/app/register-editor.js
+++ b/src/app/register-editor.js
@@ -1,1 +1,63 @@
-export function registerEditor() {}
+import { attachEditorApi } from '../features/editor/index.js';
+
+function isTypingTarget(target) {
+  if (!target) return false;
+  const tag = String(target.tagName || '').toLowerCase();
+  return target.isContentEditable || tag === 'input' || tag === 'textarea' || tag === 'select';
+}
+
+export function registerEditor(app) {
+  attachEditorApi(app);
+
+  window.addEventListener('keydown', (e) => {
+    if (isTypingTarget(e.target)) return;
+
+    const key = String(e.key || '').toLowerCase();
+    const meta = e.metaKey || e.ctrlKey;
+
+    if (key === 'escape') {
+      if (app.state.editor?.editSession && app.abortSceneEdit) app.abortSceneEdit();
+      else app.cancelCurrentInteraction();
+      app.clearSelection({ redraw: false });
+      app.draw();
+      e.preventDefault();
+      return;
+    }
+
+    if (key === 'delete' || key === 'backspace') {
+      e.preventDefault();
+      if (app.deleteSelectedObject && app.deleteSelectedObject()) {
+        return;
+      }
+      return;
+    }
+
+    if (meta && key === 'z') {
+      e.preventDefault();
+      if (e.shiftKey) app.redo();
+      else app.undo();
+      return;
+    }
+
+    if (meta && key === 'y') {
+      e.preventDefault();
+      app.redo();
+      return;
+    }
+
+    if (key === 'v') {
+      app.setMode('drag');
+      e.preventDefault();
+      return;
+    }
+    if (key === 'r') {
+      app.setMode('run');
+      e.preventDefault();
+      return;
+    }
+    if (key === 'p') {
+      app.setMode('pass');
+      e.preventDefault();
+    }
+  });
+}

--- a/src/board/history.js
+++ b/src/board/history.js
@@ -1,6 +1,6 @@
 export function attachHistoryApi(app) {
-  app.pushUndo = function pushUndo() {
-    app.state.undoStack.push(app.serializeScene());
+  app.pushUndo = function pushUndo(scene = app.serializeScene()) {
+    app.state.undoStack.push(JSON.parse(JSON.stringify(scene)));
     if (app.state.undoStack.length > 50) app.state.undoStack.shift();
     app.state.redoStack.length = 0;
   };
@@ -8,14 +8,14 @@ export function attachHistoryApi(app) {
   app.undo = function undo() {
     if (!app.state.undoStack.length) return;
     const last = app.state.undoStack.pop();
-    app.state.redoStack.push(app.serializeScene());
+    app.state.redoStack.push(app.captureSceneSnapshot ? app.captureSceneSnapshot() : app.serializeScene());
     app.restoreScene(last);
   };
 
   app.redo = function redo() {
     if (!app.state.redoStack.length) return;
     const next = app.state.redoStack.pop();
-    app.state.undoStack.push(app.serializeScene());
+    app.state.undoStack.push(app.captureSceneSnapshot ? app.captureSceneSnapshot() : app.serializeScene());
     app.restoreScene(next);
   };
 }

--- a/src/board/interaction.js
+++ b/src/board/interaction.js
@@ -63,6 +63,7 @@ export function attachInteractionApi(app) {
       app.state.drawing = false;
       app.state.currentLine = null;
     }
+    if (app.cancelSceneEdit) app.cancelSceneEdit();
     clearTimeout(app.longPressTimer);
     app.longPressTimer = null;
     app.downPt = null;
@@ -98,21 +99,66 @@ export function attachInteractionApi(app) {
 
     if (app.state.gesture.active) return;
     const pt = app.screenToWorld(spt);
-    if (app.state.mode === 'drag') {
-      const hit = app.nearestPlayer(pt);
-      if (hit) {
-        app.state.dragTarget = hit;
-        app.downPt = spt;
-        clearTimeout(app.longPressTimer);
-        app.longPressTimer = setTimeout(() => {
-          if (hit.team === 'O') app.setBallHandler(hit);
-        }, app.LONG_PRESS_MS);
-      }
+    const shapeHit = app.hitTestShape ? app.hitTestShape(pt) : null;
+    const playerHit = app.state.mode === 'drag' && app.hitTestPlayer ? app.hitTestPlayer(pt) : null;
+
+    if (playerHit) {
+      app.setSelection({ kind: 'player', id: playerHit.id }, { redraw: false });
+      app.state.dragTarget = playerHit;
+      app.downPt = spt;
+      app.startSceneEdit({ kind: 'player', id: playerHit.id });
+      clearTimeout(app.longPressTimer);
+      app.longPressTimer = setTimeout(() => {
+        if (playerHit.team === 'O') {
+          app.pushUndo();
+          app.setBallHandler(playerHit);
+        }
+      }, app.LONG_PRESS_MS);
+      app.draw();
       return;
     }
 
+    if (shapeHit) {
+      app.setSelection({ kind: 'shape', id: shapeHit.shape.id }, { redraw: false });
+      const before = app.captureSceneSnapshot ? app.captureSceneSnapshot() : app.serializeScene();
+      if (shapeHit.kind === 'vertex') {
+        app.startSceneEdit({
+          kind: 'shape',
+          id: shapeHit.shape.id,
+          pointIndex: shapeHit.pointIndex,
+          beforeScene: before
+        });
+      } else if (shapeHit.kind === 'insert') {
+        const pointIndex = app.insertShapePoint(shapeHit.shape, shapeHit.segmentIndex, pt);
+        app.setSelection({ kind: 'shape', id: shapeHit.shape.id, pointIndex }, { redraw: false });
+        app.startSceneEdit({
+          kind: 'shape',
+          id: shapeHit.shape.id,
+          pointIndex,
+          beforeScene: before
+        });
+        app.markSceneEditChanged();
+      } else {
+        app.cancelSceneEdit();
+      }
+      app.draw();
+      return;
+    }
+
+    if (app.state.mode === 'drag') {
+      app.clearSelection({ redraw: false });
+      app.draw();
+      return;
+    }
+
+    app.clearSelection({ redraw: false });
     app.state.drawing = true;
     app.state.currentLine = { type: app.state.mode === 'run' ? 'run' : 'pass', pts: [pt] };
+    app.startSceneEdit({
+      kind: 'draw',
+      beforeScene: app.captureSceneSnapshot ? app.captureSceneSnapshot() : app.serializeScene()
+    });
+    app.draw();
   };
 
   app.onMove = function onMove(e) {
@@ -127,6 +173,14 @@ export function attachInteractionApi(app) {
     }
 
     const pt = app.screenToWorld(spt);
+    const edit = app.state.editor?.editSession || null;
+    if (edit && (edit.kind === 'player' || edit.kind === 'shape')) {
+      if (app.moveSelectedHandle(pt)) {
+        app.draw();
+      }
+      return;
+    }
+
     if (app.longPressTimer && app.downPt) {
       const dx = spt.x - app.downPt.x;
       const dy = spt.y - app.downPt.y;
@@ -174,16 +228,54 @@ export function attachInteractionApi(app) {
       return;
     }
 
+    const edit = app.state.editor?.editSession || null;
+    if (edit && (edit.kind === 'player' || edit.kind === 'shape')) {
+      app.state.dragTarget = null;
+      app.finishSceneEdit();
+      if (edit.changed) {
+        app.pushUndo(edit.beforeScene);
+      }
+      app.draw();
+      return;
+    }
+
     if (app.state.mode === 'drag') {
       app.state.dragTarget = null;
+      return;
+    }
+
+    if (edit && edit.kind === 'draw') {
+      app.finishSceneEdit();
+      if (app.state.currentLine && app.state.currentLine.pts.length > 1) {
+        app.pushUndo(edit.beforeScene);
+        const shape = {
+          id: app.allocateShapeId(app.state.currentLine.type),
+          type: app.state.currentLine.type,
+          pts: app.state.currentLine.pts.map((p) => ({ x: p.x, y: p.y }))
+        };
+        app.state.shapes.push(shape);
+        if (app.ensureShapeIds) app.ensureShapeIds();
+        app.setSelection({ kind: 'shape', id: shape.id }, { redraw: false });
+      }
+      app.state.drawing = false;
+      app.state.currentLine = null;
+      app.draw();
       return;
     }
 
     if (app.state.drawing) {
       app.state.drawing = false;
       if (app.state.currentLine && app.state.currentLine.pts.length > 1) {
-        app.pushUndo();
-        app.state.shapes.push(app.state.currentLine);
+        const editBefore = app.captureSceneSnapshot ? app.captureSceneSnapshot() : app.serializeScene();
+        app.pushUndo(editBefore);
+        const shape = {
+          id: app.allocateShapeId(app.state.currentLine.type),
+          type: app.state.currentLine.type,
+          pts: app.state.currentLine.pts.map((p) => ({ x: p.x, y: p.y }))
+        };
+        app.state.shapes.push(shape);
+        if (app.ensureShapeIds) app.ensureShapeIds();
+        app.setSelection({ kind: 'shape', id: shape.id }, { redraw: false });
       }
       app.state.currentLine = null;
       app.draw();

--- a/src/board/render.js
+++ b/src/board/render.js
@@ -394,6 +394,61 @@ export function attachRenderApi(app) {
     }
   };
 
+  app.drawSelectionOverlay = function drawSelectionOverlay() {
+    const sel = app.getSelection ? app.getSelection() : null;
+    if (!sel) return;
+    const ctx = app.ctx;
+    const edit = app.state.editor?.editSession || null;
+    const R = app.playerRadiusPx();
+
+    ctx.save();
+    if (sel.kind === 'player') {
+      const player = app.getSelectedPlayer ? app.getSelectedPlayer() : null;
+      if (player && !player.hidden) {
+        ctx.fillStyle = 'rgba(253, 230, 138, 0.10)';
+        ctx.strokeStyle = '#FDE68A';
+        ctx.lineWidth = 4;
+        ctx.beginPath();
+        ctx.arc(player.x, player.y, R + 10, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+      }
+      ctx.restore();
+      return;
+    }
+
+    if (sel.kind === 'shape') {
+      const shape = app.getSelectedShape ? app.getSelectedShape() : null;
+      if (!shape || !Array.isArray(shape.pts) || shape.pts.length < 2) {
+        ctx.restore();
+        return;
+      }
+
+      ctx.strokeStyle = '#FDE68A';
+      ctx.lineWidth = 6;
+      ctx.setLineDash([8, 6]);
+      if (shape.type === 'pass') {
+        app.drawArrow(shape.pts[0], shape.pts[shape.pts.length - 1], '#FDE68A');
+      } else {
+        app.drawPolyline(shape.pts, '#FDE68A', true);
+      }
+      ctx.setLineDash([]);
+
+      shape.pts.forEach((pt, idx) => {
+        const active = edit && edit.kind === 'shape' && edit.id === shape.id && edit.pointIndex === idx;
+        ctx.fillStyle = active ? '#0F172A' : '#FDE68A';
+        ctx.strokeStyle = active ? '#FDE68A' : '#0F172A';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.arc(pt.x, pt.y, active ? 8 : 6, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+      });
+    }
+
+    ctx.restore();
+  };
+
   app.spacingThresholdPx = function spacingThresholdPx() {
     return Math.min(app.canvas.clientWidth, app.canvas.clientHeight) * 0.09;
   };
@@ -540,6 +595,7 @@ export function attachRenderApi(app) {
     app.drawShapes();
     app.drawPlayers({ hideDefense });
     app.drawSpacingAlerts();
+    app.drawSelectionOverlay();
     ctx.restore();
     app.syncOffenseSelect();
     app.refreshAITips();

--- a/src/board/replay.js
+++ b/src/board/replay.js
@@ -113,26 +113,26 @@ export function attachReplayApi(app) {
     return out;
   };
 
-  app.compileTimeline = function compileTimeline() {
+  app.compileTimeline = function compileTimeline(scene = app.captureSceneSnapshot ? app.captureSceneSnapshot() : app.serializeScene()) {
     const runs = [];
     const passes = [];
-    const offense = app.state.players.filter((p) => p.team === 'O');
+    const offense = (scene.players || []).filter((p) => p.team === 'O');
     const nearest = (pt) => offense.reduce((memo, player) => {
       const d = Math.hypot(pt.x - player.x, pt.y - player.y);
       return (!memo || d < memo.d) ? { p: player, d } : memo;
     }, null)?.p;
 
-    app.state.shapes.filter((s) => s.type === 'run' && s.pts?.length >= 2).forEach((shape) => {
+    (scene.shapes || []).filter((s) => s.type === 'run' && s.pts?.length >= 2).forEach((shape) => {
       const player = nearest(shape.pts[0]);
       if (!player) return;
       const smooth = app.sampleSpline(shape.pts, 64);
       const adjusted = app.adjustPathForTeammates(smooth, player, offense);
       const dur = Math.max(0.2, app.polyLength(adjusted) / MOVE_SPEED);
-      runs.push({ player, pts: adjusted, t0: 0, t1: dur * 1000 });
+      runs.push({ playerId: player.id, pts: adjusted, t0: 0, t1: dur * 1000 });
     });
 
     let idx = 0;
-    app.state.shapes.filter((s) => s.type === 'pass' && s.pts?.length >= 2).forEach((shape) => {
+    (scene.shapes || []).filter((s) => s.type === 'pass' && s.pts?.length >= 2).forEach((shape) => {
       const a = shape.pts[0];
       const b = shape.pts.at(-1);
       const from = nearest(a);
@@ -142,7 +142,7 @@ export function attachReplayApi(app) {
       const dur = Math.max(0.2, dist / PASS_SPEED);
       const t0 = BASE_DELAY + idx * 300;
       const arc = Math.max(28, Math.min(84, dist * 0.18));
-      passes.push({ from, to, p0: a, p1: b, t0, dur: dur * 1000, arc });
+      passes.push({ fromId: from.id, toId: to.id, p0: a, p1: b, t0, dur: dur * 1000, arc });
       idx += 1;
     });
 
@@ -155,12 +155,9 @@ export function attachReplayApi(app) {
   };
 
   app.startReplay = function startReplay() {
-    app.state.replay.snapshot = {
-      players: JSON.parse(JSON.stringify(app.state.players)),
-      ballOwnerId: app.state.players.find((p) => p.team === 'O' && p.ball)?.id || null
-    };
+    app.state.replay.snapshot = app.captureSceneSnapshot ? app.captureSceneSnapshot() : app.serializeScene();
     app.canvas.style.pointerEvents = 'none';
-    const tl = app.compileTimeline();
+    const tl = app.compileTimeline(app.state.replay.snapshot);
     app.state.replay.runs = tl.runs;
     app.state.replay.passes = tl.passes;
     app.state.replay.durationMs = Math.max(100, tl.durationMs);
@@ -180,10 +177,7 @@ export function attachReplayApi(app) {
     app.state.replay.paused = false;
     app.canvas.style.pointerEvents = 'auto';
     if (restore && app.state.replay.snapshot) {
-      app.state.players = JSON.parse(JSON.stringify(app.state.replay.snapshot.players));
-      app.state.players.forEach((p) => {
-        p.ball = p.team === 'O' && p.id === app.state.replay.snapshot.ballOwnerId;
-      });
+      app.restoreScene(app.state.replay.snapshot, { redraw: false });
     }
     app.state.replay.flightBall = null;
     app.draw();
@@ -209,11 +203,15 @@ export function attachReplayApi(app) {
   app.setReplayTime = function setReplayTime(ms) {
     const t = Math.max(0, Math.min(app.state.replay.durationMs, ms | 0));
     app.state.replay.timeMs = t;
+    const snapshot = app.state.replay.snapshot || app.captureSceneSnapshot?.() || app.serializeScene();
     app.state.replay.runs.forEach((run) => {
       const u = (t < run.t0) ? 0 : (t > run.t1 ? 1 : (t - run.t0) / (run.t1 - run.t0));
       const pos = app.polyLerp(run.pts, Math.max(0, Math.min(1, u)));
-      run.player.x = pos.x;
-      run.player.y = pos.y;
+      const live = app.state.players.find((player) => player.id === run.playerId);
+      if (live) {
+        live.x = pos.x;
+        live.y = pos.y;
+      }
     });
     app.state.players.forEach((p) => {
       if (p.team === 'O') p.ball = false;
@@ -231,7 +229,7 @@ export function attachReplayApi(app) {
       const arcY = -4 * inFlight.arc * u * (1 - u);
       app.state.replay.flightBall = { x: base.x, y: base.y + arcY };
     } else {
-      const targetId = lastDone ? lastDone.to.id : app.state.replay.snapshot.ballOwnerId;
+      const targetId = lastDone ? lastDone.toId : snapshot.ballHandlerId;
       const holder = app.state.players.find((p) => p.team === 'O' && p.id === targetId);
       if (holder) holder.ball = true;
     }

--- a/src/board/scene.js
+++ b/src/board/scene.js
@@ -36,6 +36,10 @@ function createInitialState() {
     },
     uiLang: 'zh',
     playerSize: 'normal',
+    editor: {
+      selection: null,
+      editSession: null
+    },
     immersive: {
       enabled: false,
       side: 'right'
@@ -54,11 +58,13 @@ function createInitialState() {
 
 export function attachSceneApi(app) {
   app.state = createInitialState();
+  app.shapeSeq = 0;
   app.saveExportOpts = function saveExportOpts() {
     localStorage.setItem(EXPORT_OPTS_KEY, JSON.stringify(app.state.exportOpts));
   };
 
   app.serializeScene = function serializeScene() {
+    if (app.ensureShapeIds) app.ensureShapeIds();
     return {
       schema: SAVE_SCHEMA,
       court: app.state.court,
@@ -127,6 +133,12 @@ export function attachSceneApi(app) {
     });
     if (app.state.dragTarget && app.state.dragTarget.team === 'D') {
       app.state.dragTarget = null;
+    }
+    if (app.state.editor?.selection?.kind === 'player') {
+      const selected = app.state.players.find((p) => p.id === app.state.editor.selection.id);
+      if (selected && selected.team === 'D' && selected.hidden && app.clearSelection) {
+        app.clearSelection({ redraw: false });
+      }
     }
     app.updateDefenseToggleButton();
     if (app.draw) app.draw();
@@ -290,11 +302,17 @@ export function attachSceneApi(app) {
 
   app.restoreScene = function restoreScene(scene, opts = {}) {
     if (!scene) return false;
+    if (app.cancelCurrentInteraction) app.cancelCurrentInteraction();
     app.state.court = scene.court === 'full' ? 'full' : 'half';
     app.state.players = JSON.parse(JSON.stringify(scene.players || []));
     app.state.shapes = JSON.parse(JSON.stringify(scene.shapes || []));
+    if (app.ensureShapeIds) app.ensureShapeIds();
     app.normalizePlayerVisibility();
     app.applied.id = scene.appliedPlayId || null;
+    if (app.state.editor) {
+      app.state.editor.selection = null;
+      app.state.editor.editSession = null;
+    }
     if (scene.ballHandlerId) {
       app.setBallHandlerById(String(scene.ballHandlerId), { silent: true, redraw: false });
     }

--- a/src/catalog/plays.js
+++ b/src/catalog/plays.js
@@ -180,13 +180,17 @@ export function attachPlaysApi(app) {
     }
     if (Array.isArray(play.shapes)) {
       app.state.shapes = play.shapes.map((s) => ({
+        id: s.id || app.allocateShapeId(s.type === 'pass' ? 'pass' : 'run'),
         type: s.type === 'pass' ? 'pass' : 'run',
         pts: (s.pts || []).map(app.normToPx)
       }));
+      if (app.ensureShapeIds) app.ensureShapeIds();
     }
     if (play.ballHandler) {
       app.setBallHandlerById(String(play.ballHandler), { silent: true, redraw: false });
     }
+    if (app.clearSelection) app.clearSelection({ redraw: false });
+    if (app.cancelSceneEdit) app.cancelSceneEdit();
     app.draw();
   };
 

--- a/src/features/editor/index.js
+++ b/src/features/editor/index.js
@@ -1,0 +1,231 @@
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function shapeSeqFromId(id) {
+  const match = /-(\d+)$/.exec(String(id || ''));
+  return match ? Number(match[1]) : 0;
+}
+
+function dist(a, b) {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+export function attachEditorApi(app) {
+  if (!app.state.editor) {
+    app.state.editor = {
+      selection: null,
+      editSession: null
+    };
+  }
+  app.shapeSeq = 0;
+
+  app.captureSceneSnapshot = function captureSceneSnapshot() {
+    return clone(app.serializeScene());
+  };
+
+  app.allocateShapeId = function allocateShapeId(prefix = 'shape') {
+    app.shapeSeq += 1;
+    return `${prefix}-${app.shapeSeq}`;
+  };
+
+  app.ensureShapeIds = function ensureShapeIds(shapes = app.state.shapes) {
+    let maxSeq = app.shapeSeq;
+    (shapes || []).forEach((shape, idx) => {
+      if (!shape) return;
+      shape.type = shape.type === 'pass' ? 'pass' : 'run';
+      if (!Array.isArray(shape.pts)) shape.pts = [];
+      if (!shape.id) shape.id = app.allocateShapeId(shape.type || 'shape');
+      maxSeq = Math.max(maxSeq, shapeSeqFromId(shape.id), idx + 1);
+    });
+    app.shapeSeq = maxSeq;
+    return shapes;
+  };
+
+  app.setSelection = function setSelection(selection, opts = {}) {
+    app.state.editor.selection = selection ? clone(selection) : null;
+    if (opts.redraw !== false && app.draw) app.draw();
+    return app.state.editor.selection;
+  };
+
+  app.clearSelection = function clearSelection(opts = {}) {
+    return app.setSelection(null, opts);
+  };
+
+  app.getSelection = function getSelection() {
+    return app.state.editor.selection;
+  };
+
+  app.getSelectedPlayer = function getSelectedPlayer() {
+    const sel = app.getSelection();
+    if (!sel || sel.kind !== 'player') return null;
+    return app.state.players.find((player) => player.id === sel.id) || null;
+  };
+
+  app.getSelectedShape = function getSelectedShape() {
+    const sel = app.getSelection();
+    if (!sel || sel.kind !== 'shape') return null;
+    return app.state.shapes.find((shape) => shape.id === sel.id) || null;
+  };
+
+  app.distanceToSegment = function distanceToSegment(pt, a, b) {
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const len2 = dx * dx + dy * dy;
+    if (!len2) return dist(pt, a);
+    let t = ((pt.x - a.x) * dx + (pt.y - a.y) * dy) / len2;
+    t = Math.max(0, Math.min(1, t));
+    const x = a.x + t * dx;
+    const y = a.y + t * dy;
+    return { d: Math.hypot(pt.x - x, pt.y - y), x, y, t };
+  };
+
+  app.hitTestPlayer = function hitTestPlayer(pt) {
+    let hit = null;
+    let min = Infinity;
+    const R = app.playerRadiusPx();
+    app.state.players.forEach((player) => {
+      if (!player || player.hidden) return;
+      const d = dist(pt, player);
+      if (d <= R * 1.2 && d < min) {
+        min = d;
+        hit = player;
+      }
+    });
+    return hit;
+  };
+
+  app.nearestPlayer = app.hitTestPlayer;
+
+  app.hitTestShape = function hitTestShape(pt) {
+    const threshold = Math.max(12, app.playerRadiusPx() * 0.75);
+    for (let i = app.state.shapes.length - 1; i >= 0; i -= 1) {
+      const shape = app.state.shapes[i];
+      const pts = Array.isArray(shape?.pts) ? shape.pts : [];
+      if (pts.length < 2) continue;
+
+      for (let p = 0; p < pts.length; p += 1) {
+        if (dist(pt, pts[p]) <= threshold) {
+          return { shape, kind: 'vertex', pointIndex: p, point: clone(pts[p]) };
+        }
+      }
+
+      let best = null;
+      for (let s = 1; s < pts.length; s += 1) {
+        const probe = app.distanceToSegment(pt, pts[s - 1], pts[s]);
+        if (!best || probe.d < best.d) {
+          best = { ...probe, segmentIndex: s - 1 };
+        }
+      }
+      if (best && best.d <= threshold) {
+        if (shape.type === 'pass') {
+          return { shape, kind: 'body', segmentIndex: best.segmentIndex, point: { x: best.x, y: best.y } };
+        }
+        return {
+          shape,
+          kind: 'insert',
+          segmentIndex: best.segmentIndex,
+          pointIndex: best.segmentIndex + 1,
+          point: { x: best.x, y: best.y }
+        };
+      }
+    }
+    return null;
+  };
+
+  app.startSceneEdit = function startSceneEdit(session) {
+    app.state.editor.editSession = {
+      beforeScene: session.beforeScene ? clone(session.beforeScene) : app.captureSceneSnapshot(),
+      kind: session.kind || 'shape',
+      id: session.id || null,
+      pointIndex: Number.isInteger(session.pointIndex) ? session.pointIndex : null,
+      segmentIndex: Number.isInteger(session.segmentIndex) ? session.segmentIndex : null,
+      changed: false
+    };
+    return app.state.editor.editSession;
+  };
+
+  app.markSceneEditChanged = function markSceneEditChanged() {
+    if (app.state.editor.editSession) app.state.editor.editSession.changed = true;
+  };
+
+  app.finishSceneEdit = function finishSceneEdit() {
+    const edit = app.state.editor.editSession;
+    app.state.editor.editSession = null;
+    return edit;
+  };
+
+  app.cancelSceneEdit = function cancelSceneEdit() {
+    app.state.editor.editSession = null;
+  };
+
+  app.abortSceneEdit = function abortSceneEdit() {
+    const edit = app.state.editor.editSession;
+    if (edit?.beforeScene) {
+      app.restoreScene(edit.beforeScene, { redraw: false });
+      return true;
+    }
+    app.cancelSceneEdit();
+    return false;
+  };
+
+  app.moveSelectedHandle = function moveSelectedHandle(pt) {
+    const edit = app.state.editor.editSession;
+    if (!edit || !Number.isFinite(pt?.x) || !Number.isFinite(pt?.y)) return false;
+    if (edit.kind === 'player') {
+      const player = app.state.players.find((item) => item.id === edit.id);
+      if (!player) return false;
+      player.x = pt.x;
+      player.y = pt.y;
+      app.markSceneEditChanged();
+      return true;
+    }
+    if (edit.kind === 'shape') {
+      const shape = app.state.shapes.find((item) => item.id === edit.id);
+      if (!shape || !Array.isArray(shape.pts)) return false;
+      if (!Number.isInteger(edit.pointIndex) || !shape.pts[edit.pointIndex]) return false;
+      shape.pts[edit.pointIndex] = { x: pt.x, y: pt.y };
+      app.markSceneEditChanged();
+      return true;
+    }
+    return false;
+  };
+
+  app.insertShapePoint = function insertShapePoint(shape, segmentIndex, pt) {
+    if (!shape || !Array.isArray(shape.pts)) return null;
+    const insertAt = Math.max(0, Math.min(shape.pts.length, segmentIndex + 1));
+    shape.pts.splice(insertAt, 0, { x: pt.x, y: pt.y });
+    return insertAt;
+  };
+
+  app.deleteSelectedObject = function deleteSelectedObject() {
+    const sel = app.getSelection();
+    if (!sel) return false;
+    const before = app.captureSceneSnapshot();
+    if (app.cancelCurrentInteraction) app.cancelCurrentInteraction();
+
+    if (sel.kind === 'shape') {
+      const idx = app.state.shapes.findIndex((shape) => shape.id === sel.id);
+      if (idx < 0) return false;
+      app.pushUndo(before);
+      app.state.shapes.splice(idx, 1);
+      app.clearSelection({ redraw: false });
+      if (app.draw) app.draw();
+      return true;
+    }
+
+    if (sel.kind === 'player') {
+      const player = app.state.players.find((item) => item.id === sel.id);
+      if (!player || player.team !== 'D') return false;
+      app.pushUndo(before);
+      player.hidden = true;
+      if (player.ball) player.ball = false;
+      app.clearSelection({ redraw: false });
+      if (app.updateDefenseToggleButton) app.updateDefenseToggleButton();
+      if (app.draw) app.draw();
+      return true;
+    }
+
+    return false;
+  };
+}


### PR DESCRIPTION
Closes #4
Part of #3

## Summary
- replace shape-only history with full-scene snapshots
- add object selection for defenders and drawn shapes
- support selected-object delete, shape handle editing, and replay based on scene snapshots

## Notes
- this PR is stacked on top of #10
- kept the board as static HTML/JS and preserved current replay/theme/library flows

## Smoke Test
- board boot verified in a browser from the branch worktree
- editor APIs verified from the browser: selection present, defender delete works, undo restores defender, shape delete/undo works
- `node --check` run on all changed JS files

## Preview
- preview deploy pending Vercel project linking in the quality/deploy lane