### PR TITLE
Feature: keyboard shortcuts, accessibility, smoke tests, and Vercel previews

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,32 @@
+name: Smoke Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 'codex/**'
+      - 'feat/**'
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install --no-fund --no-audit
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run smoke tests
+        run: npm test

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,0 +1,76 @@
+name: Vercel Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+    steps:
+      - name: Check Vercel configuration
+        id: vercel-config
+        run: |
+          if [ -z "${{ secrets.VERCEL_TOKEN }}" ] || [ -z "$VERCEL_ORG_ID" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "Vercel preview skipped: missing VERCEL_TOKEN, VERCEL_ORG_ID, or VERCEL_PROJECT_ID." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.vercel-config.outputs.configured == 'true'
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        if: steps.vercel-config.outputs.configured == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Vercel CLI
+        if: steps.vercel-config.outputs.configured == 'true'
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment
+        if: steps.vercel-config.outputs.configured == 'true'
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build preview artifacts
+        if: steps.vercel-config.outputs.configured == 'true'
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy preview
+        if: steps.vercel-config.outputs.configured == 'true'
+        id: deploy
+        run: |
+          url="$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Preview deployment: $url" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish PR comment
+        if: github.event_name == 'pull_request' && steps.vercel-config.outputs.configured == 'true'
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+        with:
+          script: |
+            const marker = '<!-- vercel-preview-comment -->';
+            const body = `${marker}\nVercel preview: ${process.env.DEPLOYMENT_URL}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
+            const existing = comments.find((comment) => comment.user.type === 'Bot' && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "ai-hoops-board",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-hoops-board",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ai-hoops-board",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "serve:static": "python3 -m http.server 4173 --bind 127.0.0.1",
+    "test": "playwright test",
+    "test:smoke": "playwright test tests/smoke.spec.js"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  fullyParallel: false,
+  workers: 1,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    headless: true,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    viewport: { width: 1440, height: 1024 }
+  },
+  webServer: {
+    command: 'python3 -m http.server 4173 --bind 127.0.0.1',
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+    timeout: 15_000
+  }
+});

--- a/src/app/register-quality.js
+++ b/src/app/register-quality.js
@@ -1,1 +1,7 @@
-export function registerQuality() {}
+import { registerAccessibility } from '../features/a11y/index.js';
+import { registerShortcuts } from '../features/shortcuts/index.js';
+
+export function registerQuality(app) {
+  registerAccessibility(app);
+  registerShortcuts(app);
+}

--- a/src/features/a11y/index.js
+++ b/src/features/a11y/index.js
@@ -1,0 +1,248 @@
+const COPY = {
+  zh: {
+    shortcutsLabel: '键盘快捷键帮助',
+    shortcutsHelp: '快捷键：V 拖拽，R 跑位线，P 传球箭头，D 移除或恢复防守，C 切换半场全场，F 切换沉浸模式，A 展开更多，空格回放或暂停，Esc 停止回放或关闭浮层，Ctrl 或 Command 加 S 保存，Ctrl 或 Command 加 Z 撤销，Shift 加 Ctrl 或 Command 加 Z 重做。',
+    boardLabel: '篮球战术画板。可用快捷键切换工具，画板说明见下方提示。',
+    mainToolbar: '主工具栏',
+    advancedToolbar: '扩展工具栏',
+    bottomToolbar: '底部操作栏',
+    liveRegion: '战术板状态播报',
+    overlay: '战术板弹层',
+    playPause: '回放或暂停',
+    stopReplay: '停止回放',
+    toggleMore: '展开或收起更多工具',
+    focusCanvas: '已聚焦画板。',
+    overlayClosed: '已关闭弹层。'
+  },
+  en: {
+    shortcutsLabel: 'Keyboard shortcuts help',
+    shortcutsHelp: 'Shortcuts: V drag, R run line, P pass arrow, D remove or restore defense, C toggle half or full court, F toggle immersive mode, A toggle more tools, Space replay or pause, Escape stop replay or close overlay, Ctrl or Command plus S save, Ctrl or Command plus Z undo, Shift plus Ctrl or Command plus Z redo.',
+    boardLabel: 'Basketball tactics board. Use keyboard shortcuts to switch tools. The board hint is announced below the canvas.',
+    mainToolbar: 'Main toolbar',
+    advancedToolbar: 'Advanced toolbar',
+    bottomToolbar: 'Bottom action bar',
+    liveRegion: 'Board status announcements',
+    overlay: 'Board overlay',
+    playPause: 'Replay or pause',
+    stopReplay: 'Stop replay',
+    toggleMore: 'Expand or collapse more tools',
+    focusCanvas: 'Board focused.',
+    overlayClosed: 'Overlay closed.'
+  }
+};
+
+function copyFor(app) {
+  const lang = app.normalizeLang?.(app.state?.uiLang) || 'zh';
+  return COPY[lang] || COPY.zh;
+}
+
+function createVisuallyHiddenStyle(doc) {
+  if (doc.getElementById('quality-a11y-style')) return;
+  const style = doc.createElement('style');
+  style.id = 'quality-a11y-style';
+  style.textContent = `
+    .sr-only {
+      position: absolute !important;
+      width: 1px !important;
+      height: 1px !important;
+      padding: 0 !important;
+      margin: -1px !important;
+      overflow: hidden !important;
+      clip: rect(0, 0, 0, 0) !important;
+      white-space: nowrap !important;
+      border: 0 !important;
+    }
+
+    :focus-visible {
+      outline: 3px solid color-mix(in srgb, var(--accent-soft, #fb923c) 85%, white);
+      outline-offset: 3px;
+    }
+  `;
+  doc.head.appendChild(style);
+}
+
+function ensureHiddenHelp(doc) {
+  let el = doc.getElementById('quality-shortcuts-help');
+  if (el) return el;
+  el = doc.createElement('p');
+  el.id = 'quality-shortcuts-help';
+  el.className = 'sr-only';
+  doc.body.appendChild(el);
+  return el;
+}
+
+function ensureLiveRegion(doc) {
+  let el = doc.getElementById('app-live-region');
+  if (el) return el;
+  el = doc.createElement('div');
+  el.id = 'app-live-region';
+  el.className = 'sr-only';
+  el.setAttribute('role', 'status');
+  el.setAttribute('aria-live', 'polite');
+  el.setAttribute('aria-atomic', 'true');
+  doc.body.appendChild(el);
+  return el;
+}
+
+function setShortcutAttrs(app) {
+  const shortcuts = {
+    'mode-drag': 'V',
+    'mode-run': 'R',
+    'mode-pass': 'P',
+    undo: 'Control+Z Meta+Z',
+    redo: 'Control+Shift+Z Meta+Shift+Z Control+Y',
+    'toggle-defense': 'D',
+    'toggle-court': 'C',
+    'toggle-immersive': 'F',
+    'show-advanced': 'A',
+    'btn-playpause': 'Space',
+    'btn-stop': 'Escape',
+    save: 'Control+S Meta+S',
+    'reset-view': '0'
+  };
+
+  Object.entries(shortcuts).forEach(([id, value]) => {
+    const el = app.refs.$(id);
+    if (!el) return;
+    el.setAttribute('aria-keyshortcuts', value);
+  });
+}
+
+export function registerAccessibility(app) {
+  const doc = app.document;
+  const win = app.window;
+  let overlayReturnFocus = null;
+
+  createVisuallyHiddenStyle(doc);
+  const liveRegion = ensureLiveRegion(doc);
+  const shortcutsHelp = ensureHiddenHelp(doc);
+
+  app.announce = function announce(message, politeness = 'polite') {
+    if (!message) return;
+    liveRegion.setAttribute('aria-live', politeness);
+    liveRegion.textContent = '';
+    win.clearTimeout(app._announceTimer);
+    app._announceTimer = win.setTimeout(() => {
+      liveRegion.textContent = String(message);
+    }, 32);
+  };
+
+  const originalToast = typeof app.toast === 'function' ? app.toast.bind(app) : null;
+  app.toast = function toastWithAnnouncement(message) {
+    if (originalToast) originalToast(message);
+    app.announce(message);
+  };
+
+  const originalOpenOverlay = typeof app.openOverlay === 'function' ? app.openOverlay.bind(app) : null;
+  if (originalOpenOverlay) {
+    app.openOverlay = function openOverlayWithFocus(...args) {
+      const active = doc.activeElement;
+      overlayReturnFocus = active instanceof win.HTMLElement ? active : null;
+      originalOpenOverlay(...args);
+      const root = app.refs.overlayRoot;
+      if (!root) return;
+      root.hidden = false;
+      root.setAttribute('aria-hidden', 'false');
+      root.setAttribute('role', 'dialog');
+      root.setAttribute('aria-modal', 'true');
+      root.setAttribute('aria-label', copyFor(app).overlay);
+      if (!root.hasAttribute('tabindex')) root.tabIndex = -1;
+      const focusable = root.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      (focusable || root).focus();
+    };
+  }
+
+  const originalCloseOverlay = typeof app.closeOverlay === 'function' ? app.closeOverlay.bind(app) : null;
+  if (originalCloseOverlay) {
+    app.closeOverlay = function closeOverlayWithFocus(...args) {
+      originalCloseOverlay(...args);
+      const root = app.refs.overlayRoot;
+      if (root) {
+        root.setAttribute('aria-hidden', 'true');
+        root.removeAttribute('role');
+        root.removeAttribute('aria-modal');
+        root.removeAttribute('aria-label');
+      }
+      if (overlayReturnFocus && overlayReturnFocus.isConnected) overlayReturnFocus.focus();
+      app.announce(copyFor(app).overlayClosed);
+    };
+  }
+
+  function applyAttributes() {
+    const copy = copyFor(app);
+
+    shortcutsHelp.textContent = copy.shortcutsHelp;
+    liveRegion.setAttribute('aria-label', copy.liveRegion);
+
+    doc.querySelectorAll('button').forEach((button) => {
+      if (!button.getAttribute('type')) button.setAttribute('type', 'button');
+    });
+
+    if (app.refs.toolbarEl) {
+      app.refs.toolbarEl.setAttribute('role', 'toolbar');
+      app.refs.toolbarEl.setAttribute('aria-label', copy.mainToolbar);
+    }
+    if (app.refs.advancedToolbar) {
+      app.refs.advancedToolbar.setAttribute('role', 'group');
+      app.refs.advancedToolbar.setAttribute('aria-label', copy.advancedToolbar);
+      app.refs.advancedToolbar.id = app.refs.advancedToolbar.id || 'advanced-toolbar';
+    }
+    if (app.refs.bottombarEl) {
+      app.refs.bottombarEl.setAttribute('role', 'group');
+      app.refs.bottombarEl.setAttribute('aria-label', copy.bottomToolbar);
+    }
+    if (app.refs.aiStrip) {
+      app.refs.aiStrip.setAttribute('role', 'status');
+      app.refs.aiStrip.setAttribute('aria-live', 'polite');
+      app.refs.aiStrip.setAttribute('aria-atomic', 'true');
+    }
+    if (app.canvas) {
+      app.canvas.tabIndex = 0;
+      app.canvas.setAttribute('role', 'img');
+      app.canvas.setAttribute('aria-label', copy.boardLabel);
+      const describedBy = ['board-hint', 'ai-strip', 'quality-shortcuts-help'];
+      app.canvas.setAttribute('aria-describedby', describedBy.join(' '));
+    }
+    if (app.refs.overlayRoot) {
+      app.refs.overlayRoot.setAttribute('aria-hidden', app.refs.overlayRoot.hidden ? 'true' : 'false');
+    }
+
+    const showAdvanced = app.refs.$('show-advanced');
+    if (showAdvanced && app.refs.advancedToolbar) {
+      showAdvanced.setAttribute('aria-controls', app.refs.advancedToolbar.id);
+      showAdvanced.setAttribute('aria-expanded', app.refs.advancedToolbar.classList.contains('show') ? 'true' : 'false');
+      showAdvanced.setAttribute('aria-label', copy.toggleMore);
+    }
+
+    const playPause = app.refs.$('btn-playpause');
+    if (playPause) playPause.setAttribute('aria-label', copy.playPause);
+    const stopReplay = app.refs.$('btn-stop');
+    if (stopReplay) stopReplay.setAttribute('aria-label', copy.stopReplay);
+
+    setShortcutAttrs(app);
+  }
+
+  const originalRenderLanguageUI = typeof app.renderLanguageUI === 'function' ? app.renderLanguageUI.bind(app) : null;
+  if (originalRenderLanguageUI) {
+    app.renderLanguageUI = function renderLanguageUIWithAccessibility(...args) {
+      const result = originalRenderLanguageUI(...args);
+      applyAttributes();
+      return result;
+    };
+  }
+
+  const advancedObserver = app.refs.advancedToolbar
+    ? new win.MutationObserver(() => applyAttributes())
+    : null;
+  if (advancedObserver) {
+    advancedObserver.observe(app.refs.advancedToolbar, { attributes: true, attributeFilter: ['class'] });
+  }
+
+  if (app.canvas) {
+    app.canvas.addEventListener('focus', () => {
+      app.announce(copyFor(app).focusCanvas);
+    });
+  }
+
+  applyAttributes();
+}

--- a/src/features/a11y/index.js
+++ b/src/features/a11y/index.js
@@ -112,6 +112,7 @@ export function registerAccessibility(app) {
   const doc = app.document;
   const win = app.window;
   let overlayReturnFocus = null;
+  let overlayTrapHandler = null;
 
   createVisuallyHiddenStyle(doc);
   const liveRegion = ensureLiveRegion(doc);
@@ -147,8 +148,34 @@ export function registerAccessibility(app) {
       root.setAttribute('aria-modal', 'true');
       root.setAttribute('aria-label', copyFor(app).overlay);
       if (!root.hasAttribute('tabindex')) root.tabIndex = -1;
-      const focusable = root.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
-      (focusable || root).focus();
+      const focusable = root.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      const first = focusable[0] || root;
+      const last = focusable[focusable.length - 1] || root;
+      if (overlayTrapHandler) {
+        root.removeEventListener('keydown', overlayTrapHandler, true);
+      }
+      overlayTrapHandler = (event) => {
+        if (event.key !== 'Tab') return;
+        const activeEl = doc.activeElement;
+        if (!focusable.length) {
+          event.preventDefault();
+          root.focus();
+          return;
+        }
+        if (event.shiftKey) {
+          if (activeEl === first || activeEl === root) {
+            event.preventDefault();
+            last.focus();
+          }
+          return;
+        }
+        if (activeEl === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      };
+      root.addEventListener('keydown', overlayTrapHandler, true);
+      first.focus();
     };
   }
 
@@ -158,6 +185,10 @@ export function registerAccessibility(app) {
       originalCloseOverlay(...args);
       const root = app.refs.overlayRoot;
       if (root) {
+        if (overlayTrapHandler) {
+          root.removeEventListener('keydown', overlayTrapHandler, true);
+          overlayTrapHandler = null;
+        }
         root.setAttribute('aria-hidden', 'true');
         root.removeAttribute('role');
         root.removeAttribute('aria-modal');

--- a/src/features/shortcuts/index.js
+++ b/src/features/shortcuts/index.js
@@ -1,0 +1,149 @@
+const COPY = {
+  zh: {
+    shortcutsHelp: '快捷键已启用：V 拖拽，R 跑位线，P 传球箭头，D 防守，C 半场全场，F 沉浸模式，A 更多，空格回放。',
+    modeDrag: '已切换到拖拽模式',
+    modeRun: '已切换到跑位线模式',
+    modePass: '已切换到传球箭头模式',
+    immersiveOn: '已开启沉浸模式',
+    immersiveOff: '已切换回原版布局',
+    advancedOpen: '已展开更多工具',
+    advancedClose: '已收起更多工具',
+    replayStopped: '已停止回放'
+  },
+  en: {
+    shortcutsHelp: 'Shortcuts enabled: V drag, R run line, P pass arrow, D defense, C half or full court, F immersive mode, A more tools, Space replay.',
+    modeDrag: 'Switched to drag mode',
+    modeRun: 'Switched to run line mode',
+    modePass: 'Switched to pass arrow mode',
+    immersiveOn: 'Immersive mode enabled',
+    immersiveOff: 'Returned to the original layout',
+    advancedOpen: 'More tools expanded',
+    advancedClose: 'More tools collapsed',
+    replayStopped: 'Replay stopped'
+  }
+};
+
+function copyFor(app) {
+  const lang = app.normalizeLang?.(app.state?.uiLang) || 'zh';
+  return COPY[lang] || COPY.zh;
+}
+
+function isEditableTarget(target) {
+  return !!target?.closest?.('input, textarea, select, [contenteditable=""], [contenteditable="true"]');
+}
+
+function isInteractiveTarget(target) {
+  return !!target?.closest?.('button, a, input, select, textarea, [role="dialog"], [contenteditable=""], [contenteditable="true"]');
+}
+
+function triggerClick(el) {
+  if (!el || typeof el.click !== 'function') return false;
+  el.click();
+  return true;
+}
+
+export function registerShortcuts(app) {
+  const doc = app.document;
+
+  doc.addEventListener('keydown', (event) => {
+    const lower = String(event.key || '').toLowerCase();
+    const editable = isEditableTarget(event.target);
+    const interactive = isInteractiveTarget(event.target);
+    const withMod = event.metaKey || event.ctrlKey;
+
+    if (withMod && lower === 's') {
+      event.preventDefault();
+      triggerClick(app.refs.$('save'));
+      return;
+    }
+    if (withMod && lower === 'z') {
+      event.preventDefault();
+      if (event.shiftKey) app.redo();
+      else app.undo();
+      return;
+    }
+    if (withMod && lower === 'y') {
+      event.preventDefault();
+      app.redo();
+      return;
+    }
+
+    if (editable) return;
+    if (event.altKey || event.metaKey || event.ctrlKey) return;
+
+    if (event.key === '?') {
+      event.preventDefault();
+      app.toast(copyFor(app).shortcutsHelp);
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      if (app.refs.overlayRoot && !app.refs.overlayRoot.hidden) {
+        app.closeOverlay();
+        return;
+      }
+      if (app.state.replay?.playing) {
+        app.stopReplay();
+        app.announce?.(copyFor(app).replayStopped);
+        return;
+      }
+      if (app.refs.advancedToolbar?.classList.contains('show')) {
+        triggerClick(app.refs.$('show-advanced'));
+      }
+      return;
+    }
+
+    if (event.key === ' ' && !interactive) {
+      event.preventDefault();
+      triggerClick(app.refs.$('btn-playpause'));
+      return;
+    }
+
+    switch (lower) {
+      case 'v':
+        event.preventDefault();
+        app.setMode('drag');
+        app.announce?.(copyFor(app).modeDrag);
+        break;
+      case 'r':
+        event.preventDefault();
+        app.setMode('run');
+        app.announce?.(copyFor(app).modeRun);
+        break;
+      case 'p':
+        event.preventDefault();
+        app.setMode('pass');
+        app.announce?.(copyFor(app).modePass);
+        break;
+      case 'd':
+        event.preventDefault();
+        triggerClick(app.refs.toggleDefenseBtn);
+        break;
+      case 'c':
+        event.preventDefault();
+        triggerClick(app.refs.$('toggle-court'));
+        break;
+      case 'a':
+        event.preventDefault();
+        triggerClick(app.refs.$('show-advanced'));
+        app.announce?.(
+          app.refs.advancedToolbar?.classList.contains('show')
+            ? copyFor(app).advancedOpen
+            : copyFor(app).advancedClose
+        );
+        break;
+      case 'f':
+        event.preventDefault();
+        app.applyImmersiveMode(!app.state.immersive.enabled);
+        app.announce?.(app.state.immersive.enabled ? copyFor(app).immersiveOn : copyFor(app).immersiveOff);
+        break;
+      case '0':
+        event.preventDefault();
+        triggerClick(app.refs.$('reset-view'));
+        break;
+      default:
+        break;
+    }
+  });
+}

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+
+function attachErrorCapture(page) {
+  const errors = [];
+  page.on('pageerror', (error) => errors.push(`pageerror: ${error.message}`));
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(`console: ${message.text()}`);
+  });
+  return errors;
+}
+
+test('board bootstraps with accessibility scaffolding', async ({ page }) => {
+  const errors = attachErrorCapture(page);
+  await page.goto('/');
+  await page.waitForFunction(() => Boolean(window.__aiHoopsBoardApp));
+
+  await expect(page.locator('#board')).toBeVisible();
+  await expect(page.locator('#board')).toHaveAttribute('tabindex', '0');
+  await expect(page.locator('#toolbar')).toHaveAttribute('role', 'toolbar');
+  await expect(page.locator('#app-live-region')).toHaveAttribute('role', 'status');
+  await expect(page.locator('#show-advanced')).toHaveAttribute('aria-controls', 'advanced-toolbar');
+
+  expect(errors).toEqual([]);
+});
+
+test('keyboard shortcuts drive core board actions', async ({ page, browserName }) => {
+  test.skip(browserName !== 'chromium', 'Shortcut smoke is only run in chromium.');
+  const errors = attachErrorCapture(page);
+
+  await page.goto('/');
+  await page.waitForFunction(() => Boolean(window.__aiHoopsBoardApp));
+  await page.locator('#board').click();
+
+  await page.keyboard.press('r');
+  await expect(page.locator('#mode-run')).toHaveClass(/active/);
+
+  await page.keyboard.press('p');
+  await expect(page.locator('#mode-pass')).toHaveClass(/active/);
+
+  await page.keyboard.press('v');
+  await expect(page.locator('#mode-drag')).toHaveClass(/active/);
+
+  await page.keyboard.press('d');
+  await expect(page.locator('#toggle-defense')).toHaveAttribute('aria-pressed', 'true');
+
+  await page.keyboard.press('a');
+  await expect(page.locator('#show-advanced')).toHaveAttribute('aria-expanded', 'true');
+
+  await page.keyboard.press('f');
+  await expect(page.locator('body')).toHaveClass(/immersive/);
+
+  await page.keyboard.press(' ');
+  await expect(page.locator('#btn-playpause')).not.toHaveText(/回放|Replay/);
+
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#btn-playpause')).toHaveText(/回放|Replay/);
+
+  await page.keyboard.press('?');
+  await expect(page.locator('#app-live-region')).not.toBeEmpty();
+
+  await page.keyboard.press('Control+s');
+  await expect.poll(async () => page.evaluate(() => Boolean(localStorage.getItem('boardState_v1')))).toBe(true);
+
+  expect(errors).toEqual([]);
+});
+
+test('library, drills, and settings pages load from the static server', async ({ page }) => {
+  const paths = ['/pages/library.html', '/pages/drills.html', '/pages/settings.html'];
+  for (const path of paths) {
+    const errors = attachErrorCapture(page);
+    await page.goto(path);
+    await expect(page.locator('body')).toBeVisible();
+    expect(errors).toEqual([]);
+  }
+});

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -40,20 +40,23 @@ test('keyboard shortcuts drive core board actions', async ({ page, browserName }
   await page.keyboard.press('v');
   await expect(page.locator('#mode-drag')).toHaveClass(/active/);
 
+  const defensePressedBefore = await page.locator('#toggle-defense').getAttribute('aria-pressed');
   await page.keyboard.press('d');
-  await expect(page.locator('#toggle-defense')).toHaveAttribute('aria-pressed', 'true');
+  await expect.poll(async () => page.locator('#toggle-defense').getAttribute('aria-pressed')).not.toBe(defensePressedBefore);
 
+  const advancedExpandedBefore = await page.locator('#show-advanced').getAttribute('aria-expanded');
   await page.keyboard.press('a');
-  await expect(page.locator('#show-advanced')).toHaveAttribute('aria-expanded', 'true');
+  await expect.poll(async () => page.locator('#show-advanced').getAttribute('aria-expanded')).not.toBe(advancedExpandedBefore);
 
+  const immersiveBefore = await page.evaluate(() => document.body.classList.contains('immersive'));
   await page.keyboard.press('f');
-  await expect(page.locator('body')).toHaveClass(/immersive/);
+  await expect.poll(async () => page.evaluate(() => document.body.classList.contains('immersive'))).not.toBe(immersiveBefore);
 
   await page.keyboard.press(' ');
-  await expect(page.locator('#btn-playpause')).not.toHaveText(/回放|Replay/);
+  await expect.poll(async () => page.evaluate(() => Boolean(window.__aiHoopsBoardApp?.state?.replay?.playing))).toBe(true);
 
   await page.keyboard.press('Escape');
-  await expect(page.locator('#btn-playpause')).toHaveText(/回放|Replay/);
+  await expect.poll(async () => page.evaluate(() => Boolean(window.__aiHoopsBoardApp?.state?.replay?.playing))).toBe(false);
 
   await page.keyboard.press('?');
   await expect(page.locator('#app-live-region')).not.toBeEmpty();

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "cleanUrls": true,
+  "trailingSlash": false
+}


### PR DESCRIPTION
Closes #8
Part of #3

## Summary
- add keyboard shortcut wiring for core board actions
- add accessibility scaffolding including live announcements, aria-keyshortcuts, overlay focus restoration, and a basic overlay focus trap
- add Playwright smoke tests and GitHub Actions smoke workflow
- add a Vercel preview workflow and `vercel.json` for static preview deploys

## Notes
- this PR is stacked on top of #10
- the rescued quality work was ported from `codex/wip-quality-lane-rescue` into this clean branch

## Validation
- `npm install --no-fund --no-audit`
- `npx playwright install --with-deps chromium`
- `npm test`

## Preview
- preview workflow is included, but no live preview URL is attached from this environment because Vercel auth/secrets are not configured here